### PR TITLE
allow unsafe blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -238,3 +238,9 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# MacOS 
+*.DS_Store
+
+# Visual Studio
+*.vscode

--- a/Poker-MCCFRM/Poker-MCCFRM.csproj
+++ b/Poker-MCCFRM/Poker-MCCFRM.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <RootNamespace>Poker_MCCFRM</RootNamespace>
     <Platforms>AnyCPU;x64</Platforms>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
Allow unsafe blocks so that the run won't fail with warnings. Added MacOS temp files to gitignore too.